### PR TITLE
Fix Scheduler import path after folder restructure

### DIFF
--- a/backend/scheduler/services/schedule_service.py
+++ b/backend/scheduler/services/schedule_service.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Tuple
 
 from scheduler.services.request_parser import ScheduleRequestParser
 from scheduler.services.response_builder import ScheduleResponseBuilder
-from scheduler.timetable.scheduler import Scheduler
+from scheduler.generator.schedule_generator import Scheduler
 
 
 class ScheduleService:


### PR DESCRIPTION
A 1 line change I need someone to accept otherwise everyone will still get the broken scheduler.timetable.scheduler error.