### PR TITLE
refactor the backend files linked to time blocks

### DIFF
--- a/backend/scheduler/services/timeblock_service.py
+++ b/backend/scheduler/services/timeblock_service.py
@@ -13,21 +13,20 @@ def get_or_create_dayplan(user, date):
     Returns:
         DayPlan: The existing or newly created DayPlan.
     """
-    dayplan, _ = DayPlan.objects.get_or_create(user=user, date=date)
-    return dayplan
+    day_plan, _ = DayPlan.objects.get_or_create(user=user, date=date)
+    return day_plan
 
-
-def create_timeblock(dayplan, data, original_date):
+def prepare_timeblock_data(day_plan, data, original_date):
     """
-    Create a TimeBlock for a given DayPlan using validated data.
+    Prepare shared TimeBlock values and resolve the correct DayPlan.
 
     Args:
-        dayplan (DayPlan): The parent DayPlan.
+        day_plan (DayPlan): The original parent DayPlan.
         data (dict): TimeBlock field values.
         original_date (str): The original local date before UTC conversion.
 
     Returns:
-        TimeBlock: The created TimeBlock instance.
+        tuple: (resolved_day_plan, prepared_fields)
     """
     timezone = data.get("timezone", "UTC")
 
@@ -43,21 +42,44 @@ def create_timeblock(dayplan, data, original_date):
     )
 
     if str(start_date_utc) != str(original_date):
-        dayplan = get_or_create_dayplan(dayplan.user, start_date_utc)
+        day_plan = get_or_create_dayplan(day_plan.user, start_date_utc)
+
+    prepared_fields = {
+        "name": data.get("name"),
+        "start_time": start_time_utc,
+        "end_time": end_time_utc,
+        "location": data.get("location", ""),
+        "block_type": data.get("block_type"),
+        "description": data.get("description", ""),
+        "timezone": timezone,
+    }
+
+    return day_plan, prepared_fields
+
+
+def create_timeblock(day_plan, data, original_date):
+    """
+    Create a TimeBlock for a given DayPlan using validated data.
+
+    Args:
+        dayplan (DayPlan): The parent DayPlan.
+        data (dict): TimeBlock field values.
+        original_date (str): The original local date before UTC conversion.
+
+    Returns:
+        TimeBlock: The created TimeBlock instance.
+    """
+    day_plan, prepared_fields = prepare_timeblock_data(
+        day_plan, data, original_date
+    )
 
     return TimeBlock.objects.create(
-        day=dayplan,
-        name=data.get("name"),
-        start_time=start_time_utc,
-        end_time=end_time_utc,
-        location=data.get("location", ""),
-        block_type=data["block_type"],
-        description=data.get("description", ""),
-        timezone=timezone,
+        day=day_plan,
+        **prepared_fields,
     )
 
 
-def update_timeblock(time_block, dayplan, data, original_date):
+def update_timeblock(time_block, day_plan, data, original_date):
     """
     Update an existing TimeBlock using imported calendar data.
 
@@ -71,30 +93,20 @@ def update_timeblock(time_block, dayplan, data, original_date):
         TimeBlock: The updated TimeBlock instance.
     """
 
-    timezone = data.get("timezone", "UTC")
-
-    start_time_utc, start_date_utc = to_utc(
-        str(data.get("start_time")),
-        original_date,
-        timezone,
-    )
-    end_time_utc, _ = to_utc(
-        str(data.get("end_time")),
-        original_date,
-        timezone,
+    day_plan, prepared_fields = prepare_timeblock_data(
+        day_plan, data, original_date
     )
 
-    if str(start_date_utc) != str(original_date):
-        dayplan = get_or_create_dayplan(dayplan.user, start_date_utc)
-
-    time_block.day = dayplan
-    time_block.name = data.get("name", time_block.name)
-    time_block.start_time = start_time_utc
-    time_block.end_time = end_time_utc
-    time_block.location = data.get("location", "")
-    time_block.block_type = data.get("block_type", time_block.block_type)
-    time_block.description = data.get("description", "")
-    time_block.timezone = timezone
+    time_block.day = day_plan
+    time_block.name = prepared_fields["name"] or time_block.name
+    time_block.start_time = prepared_fields["start_time"]
+    time_block.end_time = prepared_fields["end_time"]
+    time_block.location = prepared_fields["location"]
+    time_block.block_type = (
+        prepared_fields["block_type"] or time_block.block_type
+    )
+    time_block.description = prepared_fields["description"]
+    time_block.timezone = prepared_fields["timezone"]
     time_block.save()
 
     return time_block

--- a/backend/scheduler/tests/models/test_dayplan_model.py
+++ b/backend/scheduler/tests/models/test_dayplan_model.py
@@ -1,13 +1,15 @@
 from django.db import IntegrityError
 from django.test import TestCase
-from datetime import date, time
+from datetime import date
 
 from scheduler.models.DayPlan import DayPlan
-from scheduler.models.TimeBlock import TimeBlock
 from scheduler.models.User import User
 
 
 class DayPlanModelTest(TestCase):
+
+    """Tests for the DayPlan model"""
+
     def setUp(self):
         self.user = User.objects.create_user(
             username="testuser",
@@ -19,18 +21,27 @@ class DayPlanModelTest(TestCase):
         )
 
     def test_create_day_plan(self):
+        """
+        Test that a DayPlan can be successfully created and fields are correctly assigned.
+        """
         day_plan = DayPlan.objects.create(user=self.user, date=date(2026, 2, 17))
 
         self.assertEqual(day_plan.user, self.user)
         self.assertEqual(day_plan.date, date(2026, 2, 17))
 
     def test_cannot_create_duplicate_day_plan_for_same_user(self):
+        """
+        Test that creating two DayPlans for the same user and date raises an IntegrityError.
+        """
         DayPlan.objects.create(user=self.user, date=date(2026, 2, 17))
 
         with self.assertRaises(IntegrityError):
             DayPlan.objects.create(user=self.user, date=date(2026, 2, 17))
 
     def test_different_users_can_have_same_date(self):
+        """
+        Test that different users can have DayPlans for the same date without conflict.
+        """
         other_user = User.objects.create_user(
             username="user2", email="user2@test.com", password="password123"
         )

--- a/backend/scheduler/tests/models/test_time_block_model.py
+++ b/backend/scheduler/tests/models/test_time_block_model.py
@@ -7,6 +7,7 @@ from scheduler.models.User import User
 
 
 class TimeBlockModelTest(TestCase):
+    """Tests for the TimeBlock model"""
     def setUp(self):
         self.user = User.objects.create_user(
             username="testuser", password="password123"

--- a/backend/scheduler/tests/services/test_time_block_service.py
+++ b/backend/scheduler/tests/services/test_time_block_service.py
@@ -24,13 +24,39 @@ class TimeblockServiceTest(TestCase):
             date=date(2026, 1, 15),
         )
 
+        self.base_data = {
+            "name": "Default Event",
+            "start_time": "09:00",
+            "end_time": "10:00",
+            "location": "Default Location",
+            "block_type": "lecture",
+            "description": "Default description",
+            "timezone": "UTC",
+        }
+
+        self.base_update_data = {
+            "name": "Updated Event",
+            "start_time": "14:00",
+            "end_time": "15:00",
+            "location": "Updated Location",
+            "block_type": "tutorial",
+            "description": "Updated description",
+            "timezone": "UTC",
+        }
+
     def test_get_or_create_dayplan_returns_existing_dayplan(self):
+        """
+        Test that an existing DayPlan is returned and no duplicate is created.
+        """
         dayplan = get_or_create_dayplan(self.user, date(2026, 1, 15))
 
         self.assertEqual(dayplan.id, self.day_plan.id)
         self.assertEqual(DayPlan.objects.filter(user=self.user).count(), 1)
 
     def test_get_or_create_dayplan_creates_new_dayplan(self):
+        """
+        Test that a new DayPlan is created when one does not exist.
+        """
         dayplan = get_or_create_dayplan(self.user, date(2026, 1, 16))
 
         self.assertEqual(dayplan.user, self.user)
@@ -38,19 +64,23 @@ class TimeblockServiceTest(TestCase):
         self.assertEqual(DayPlan.objects.filter(user=self.user).count(), 2)
 
     def test_create_timeblock_stores_timezone_and_converts_to_utc(self):
+        """
+        Test that creating a TimeBlock correctly:
+        - converts times to UTC
+        - stores timezone and other fields
+        """
         july_day_plan = DayPlan.objects.create(
             user=self.user,
             date=date(2026, 7, 15),
         )
-        data = {
+
+        data = self.base_data.copy()
+        data.update({
             "name": "Morning Lecture",
-            "start_time": "09:00",
-            "end_time": "10:00",
-            "location": "Campus",
-            "block_type": "lecture",
-            "description": "Attend class",
             "timezone": "Europe/London",
-        }
+            "location": "Campus",
+            "description": "Attend class",
+        })
 
         block = create_timeblock(july_day_plan, data, "2026-07-15")
 
@@ -73,7 +103,11 @@ class TimeblockServiceTest(TestCase):
         self.assertEqual(block.description, "Attend class")
 
     def test_create_timeblock_moves_to_different_dayplan_when_utc_date_changes(self):
-        data = {
+        """
+        Test that a TimeBlock is moved to a different DayPlan if UTC conversion changes the date.
+        """
+        data = self.base_data.copy()
+        data.update({
             "name": "Late Study",
             "start_time": "23:30",
             "end_time": "23:59",
@@ -81,7 +115,7 @@ class TimeblockServiceTest(TestCase):
             "block_type": "study",
             "description": "Late revision",
             "timezone": "America/New_York",
-        }
+        })
 
         block = create_timeblock(self.day_plan, data, "2026-01-15")
 
@@ -98,6 +132,12 @@ class TimeblockServiceTest(TestCase):
         )
 
     def test_update_timeblock_updates_fields_and_timezone(self):
+        """
+        Test that updating a TimeBlock correctly updates:
+        - all fields
+        - UTC conversion
+        - timezone
+        """
         block = TimeBlock.objects.create(
             day=self.day_plan,
             name="Old Lecture",
@@ -109,20 +149,17 @@ class TimeblockServiceTest(TestCase):
             timezone="UTC",
         )
 
-        updated_data = {
+        data = self.base_update_data.copy()
+        data.update({
             "name": "Updated Tutorial",
-            "start_time": "14:00",
-            "end_time": "15:00",
-            "location": "New Room",
-            "block_type": "tutorial",
-            "description": "Updated description",
             "timezone": "Europe/London",
-        }
+            "location": "New Room",
+        })
 
         updated_block = update_timeblock(
             block,
             self.day_plan,
-            updated_data,
+            data,
             "2026-01-15",
         )
 
@@ -147,6 +184,9 @@ class TimeblockServiceTest(TestCase):
         self.assertEqual(updated_block.timezone, "Europe/London")
 
     def test_update_timeblock_moves_dayplan_when_utc_date_changes(self):
+        """
+        Test that updating a TimeBlock moves it to a new DayPlan when UTC conversion changes the date.
+        """
         block = TimeBlock.objects.create(
             day=self.day_plan,
             name="Late Event",
@@ -158,7 +198,8 @@ class TimeblockServiceTest(TestCase):
             timezone="UTC",
         )
 
-        updated_data = {
+        data = self.base_update_data.copy()
+        data.update({
             "name": "Late Event Updated",
             "start_time": "23:30",
             "end_time": "23:59",
@@ -166,12 +207,12 @@ class TimeblockServiceTest(TestCase):
             "block_type": "study",
             "description": "Late update",
             "timezone": "America/New_York",
-        }
+        })
 
         updated_block = update_timeblock(
             block,
             self.day_plan,
-            updated_data,
+            data,
             "2026-01-15",
         )
 


### PR DESCRIPTION
Refactored by adding comments on the test files I changed, separating dayplan into day_plan and renaming the test_timeblock_service.py to test_time_block_service.py and adding a helper functions to reduce code duplication in this file
