### PR TITLE
Add a cancel button for when you are editing a time block 

### DIFF
--- a/frontend/src/components/EditTimeBlock.jsx
+++ b/frontend/src/components/EditTimeBlock.jsx
@@ -181,6 +181,11 @@ function EditTimeBlock() {
         }
     }
 
+    function handleCancel(){
+        setServerErrors([]);
+        navigate('/calendar');
+    }
+
     if (isFetching){
         return <p>Loading...</p>;
     }
@@ -194,6 +199,7 @@ function EditTimeBlock() {
                 <h2>Edit Time Block</h2>
                 <TimeBlockForm
                     onSubmit={handleUpdate}
+                    onCancel={handleCancel}
                     initialData={initialData}
                     loading={isSubmitting}
                     serverErrors={serverErrors}

--- a/frontend/src/components/TimeBlockForm.jsx
+++ b/frontend/src/components/TimeBlockForm.jsx
@@ -11,13 +11,16 @@ import getUserTimezone from '../utils/Helpers/getUserTimezone.js';
  * - serverErrors: array of server validation errors per block
  * - clearErrors: function to clear server errors
  * - initialData: optional object for editing an existing block
+ * - onCancel: optional function to cancel editing
  */
 function TimeBlockForm({
     onSubmit,
     loading,
     serverErrors,
     clearErrors,
-    initialData = null
+    initialData = null,
+    onCancel = null
+
 }) {
     const [date, setDate] = useState(initialData?.date || '');
 
@@ -256,8 +259,20 @@ function TimeBlockForm({
                     </button>
                 )}
 
+                {initialData && onCancel && (
+                    <button
+                        className="btn cancel-btn"
+                        type="button"
+                        onClick={onCancel}
+                        disabled={loading}
+
+                    >
+                        Cancel
+                    </button>
+                )}
+
                 <button
-                    className="btn btn-primary"
+                    className={`btn ${initialData ? 'edit-btn' : 'btn-primary'}`}
                     type="submit"
                     disabled={loading}
                 >

--- a/frontend/src/components/__tests__/SuccessfulTimeBlock.test.jsx
+++ b/frontend/src/components/__tests__/SuccessfulTimeBlock.test.jsx
@@ -28,7 +28,7 @@ describe('Tests for SuccessfulTimeBlock', () => {
         ).toBeInTheDocument();
 
         expect(
-            screen.getByText('Your time block was created successfully')
+            screen.getByText(/your time block was created successfully\./i)
         ).toBeInTheDocument();
     });
 

--- a/frontend/src/components/__tests__/TimeBlockForm.test.jsx
+++ b/frontend/src/components/__tests__/TimeBlockForm.test.jsx
@@ -227,6 +227,48 @@ describe('Tests for TimeBlockForm', () => {
         ).not.toBeInTheDocument();
     });
 
+    it('calls onCancel when the cancel button is clicked in edit mode', () => {
+        const onCancel = vi.fn();
+        const initialData = {
+            id: 1,
+            date: '2026-03-24',
+            name: 'Meeting',
+            location: 'Room 2',
+            block_type: 'work',
+            description: 'Code Review',
+            start_time: '14:00',
+            end_time: '15:00'
+        };
+
+        renderTimeBlockForm({ initialData, onCancel });
+
+        const cancelButton = screen.getByRole('button', { name: /cancel/i });
+        fireEvent.click(cancelButton);
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the cancel button only in edit mode', () => {
+        expect(
+            screen.queryByRole('button', { name: /cancel/i })
+        ).not.toBeInTheDocument();
+
+        const initialData = {
+            id: 1,
+            date: '2026-03-24',
+            name: 'Meeting',
+            location: 'Room 2',
+            block_type: 'work',
+            description: 'Code Review',
+            start_time: '14:00',
+            end_time: '15:00'
+        };
+
+        renderTimeBlockForm({ initialData, onCancel: vi.fn() });
+
+        expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    });
+
     it('submits multiple blocks correctly', () => {
         const onSubmit = vi.fn();
         const timezone = getUserTimezone();

--- a/frontend/src/components/stylesheets/TimeBlockForm.css
+++ b/frontend/src/components/stylesheets/TimeBlockForm.css
@@ -55,6 +55,28 @@
     width: 250px;
 }
 
+.btn.cancel-btn {
+    background-color: var(--blue);
+    color: var(--text-white);
+    border: 1px solid var(--blue);
+}
+
+.btn.cancel-btn:hover {
+    background-color: var(--blue);
+    color: var(--text-white);
+}
+
+.btn.edit-btn {
+    background-color: var(--edit);
+    color: var(--text-white);
+    border: 1px solid var(--edit);
+}
+
+.btn.edit-btn:hover {
+    background-color: var(--edit-soft);
+    color: var(--text-main);
+}
+
 .error-text-date {
     color: var(--danger);
     font-size: 0.9rem;


### PR DESCRIPTION
I added a cancel button for the edit time block form and also changed the colour of the edit button to orange so it's consistent with the SuccessfulTimeBlock page. Additionally I added tests to TimBlockForm to cover the cancel button. Finally I had to fix a test for SuccessfulTimeBlock as the text for success was changed and this caused an old test to fail as the text it was getting was different to what was expected.