### PR TITLE
Add missing backend tests for subscription and export coverage

### DIFF
--- a/backend/scheduler/tests/helpers/test_calendar_subscription_event_text_helpers.py
+++ b/backend/scheduler/tests/helpers/test_calendar_subscription_event_text_helpers.py
@@ -4,6 +4,7 @@ from scheduler.services.calendar_subscription_event_text_helpers import (
     classify_block_type,
     clean_event_description,
     get_event_summary,
+    should_keep_description_line,
 )
 
 
@@ -48,3 +49,7 @@ class CalendarSubscriptionEventTextHelpersTest(TestCase):
         """It should return the default summary when the event summary is empty."""
         event = {"summary": ""}
         self.assertEqual(get_event_summary(event), "Imported Event")
+
+    def test_should_keep_description_line_returns_false_for_blank_line(self):
+        """It should return false for a blank description line."""
+        self.assertFalse(should_keep_description_line(""))

--- a/backend/scheduler/tests/helpers/test_calendar_subscription_validation_helpers.py
+++ b/backend/scheduler/tests/helpers/test_calendar_subscription_validation_helpers.py
@@ -52,10 +52,8 @@ class CalendarSubscriptionValidationHelpersTest(TestCase):
 
     def test_validate_unique_subscription_allows_same_url_for_different_user(self):
         """It should allow the same source URL for a different user."""
-        try:
-            validate_unique_subscription(
-                self.other_user,
-                "https://example.com/main.ics",
-            )
-        except serializers.ValidationError:
-            self.fail("validate_unique_subscription raised unexpectedly.")
+        result = validate_unique_subscription(
+            self.other_user,
+            "https://example.com/main.ics",
+        )
+        self.assertIsNone(result)

--- a/backend/scheduler/tests/helpers/test_export_ics_helpers.py
+++ b/backend/scheduler/tests/helpers/test_export_ics_helpers.py
@@ -117,3 +117,7 @@ class ExportIcsHelpersTest(TestCase):
         self.assertIn("BEGIN:VCALENDAR\r\nVERSION:2.0", content)
         self.assertIn("SUMMARY:SEG Lecture", content)
         self.assertIn("END:VCALENDAR", content)
+
+    def test_escape_ics_text_returns_empty_string_for_blank_value(self):
+        """It should return an empty string for a blank value."""
+        self.assertEqual(escape_ics_text(""), "")

--- a/backend/scheduler/tests/helpers/test_ics_datetime_helpers.py
+++ b/backend/scheduler/tests/helpers/test_ics_datetime_helpers.py
@@ -30,3 +30,8 @@ class IcsDatetimeHelpersTest(TestCase):
         """It should ignore date-only values."""
         result = normalise_ics_datetime(date(2026, 4, 10))
         self.assertIsNone(result)
+
+    def test_normalise_ics_datetime_returns_none_for_unsupported_type(self):
+        """It should return None for unsupported value types."""
+        result = normalise_ics_datetime("not a date")
+        self.assertIsNone(result)

--- a/backend/scheduler/tests/models/test_calendar_subscription_model.py
+++ b/backend/scheduler/tests/models/test_calendar_subscription_model.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+
+from scheduler.models.CalendarSubscription import CalendarSubscription
+from scheduler.models.User import User
+
+
+class CalendarSubscriptionModelTest(TestCase):
+    def setUp(self):
+        """Create reusable fixtures for calendar subscription model tests."""
+        self.user = User.objects.create_user(
+            username="subscriptionmodeluser",
+            email="subscriptionmodeluser@example.com",
+            password="password123",
+        )
+        self.subscription = CalendarSubscription.objects.create(
+            user=self.user,
+            name="KCL Timetable",
+            source_url="https://example.com/calendar.ics",
+        )
+
+    def test_str_returns_user_id_and_name(self):
+        """It should return the user id and subscription name."""
+        self.assertEqual(
+            str(self.subscription),
+            f"{self.user.id} - KCL Timetable",
+        )

--- a/backend/scheduler/tests/models/test_imported_calendar_event_model.py
+++ b/backend/scheduler/tests/models/test_imported_calendar_event_model.py
@@ -1,0 +1,50 @@
+from datetime import date, time
+
+from django.test import TestCase
+
+from scheduler.models.CalendarSubscription import CalendarSubscription
+from scheduler.models.DayPlan import DayPlan
+from scheduler.models.ImportedCalendarEvent import ImportedCalendarEvent
+from scheduler.models.TimeBlock import TimeBlock
+from scheduler.models.User import User
+
+
+class ImportedCalendarEventModelTest(TestCase):
+    def setUp(self):
+        """Create reusable fixtures for imported calendar event model tests."""
+        self.user = User.objects.create_user(
+            username="importedeventuser",
+            email="importedeventuser@example.com",
+            password="password123",
+        )
+        self.subscription = CalendarSubscription.objects.create(
+            user=self.user,
+            name="Main Calendar",
+            source_url="https://example.com/main.ics",
+        )
+        self.day_plan = DayPlan.objects.create(
+            user=self.user,
+            date=date(2026, 4, 10),
+        )
+        self.time_block = TimeBlock.objects.create(
+            day=self.day_plan,
+            name="Imported Block",
+            block_type="lecture",
+            start_time=time(9, 0),
+            end_time=time(10, 0),
+            location="Room A",
+            description="Imported event",
+            timezone="Europe/London",
+        )
+        self.imported_event = ImportedCalendarEvent.objects.create(
+            subscription=self.subscription,
+            external_event_uid="event-123",
+            time_block=self.time_block,
+        )
+
+    def test_str_returns_subscription_id_and_external_event_uid(self):
+        """It should return the subscription id and external event uid."""
+        self.assertEqual(
+            str(self.imported_event),
+            f"{self.subscription.id} - event-123",
+        )


### PR DESCRIPTION
Summary:
This PR closes the remaining backend coverage gaps for the files I was responsible for, mainly around calendar subscription helpers, export helpers, and related models.

What changed:

Added / updated tests for backend coverage gaps
- added missing edge-case coverage for `ics_datetime_helpers.py`
- added missing edge-case coverage for `calendar_subscription_event_text_helpers.py`
- added missing edge-case coverage for `export_ics_helpers.py`
- updated `test_calendar_subscription_validation_helpers.py` to remove the uncovered exception branch pattern
- added model tests for:
  - `CalendarSubscription.__str__`
  - `ImportedCalendarEvent.__str__`

Result:
The backend files that were flagged as mine are now at 100% coverage:
- `scheduler/services/ics_datetime_helpers.py`
- `scheduler/tests/helpers/test_calendar_subscription_validation_helpers.py`
- `scheduler/models/ImportedCalendarEvent.py`
- `scheduler/models/CalendarSubscription.py`
- `scheduler/services/calendar_subscription_event_text_helpers.py`
- `scheduler/services/export_ics_helpers.py`

Why:
This was done to close the remaining coverage gaps identified in the backend report and make sure the files I owned were fully covered before moving on to frontend refactoring.

Verification:
- full backend test suite passes
- coverage rerun completed successfully
- flagged backend files owned by me now reach 100% coverage